### PR TITLE
Enhance the offline detector

### DIFF
--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -372,6 +372,7 @@ class Feature {
     // false positives in the past in a vm environment.
     try {
       if (Services.io.offline ||
+          !Services.io.connectivity ||
           CaptivePortalService.state == CaptivePortalService.LOCKED_PORTAL) {
         return true;
       }


### PR DESCRIPTION
This adds an additional check that makes sure we have at least one network interface online.
Please note that, even if "offline" is false and "connectivity" is true, there's no guarantee that we have internet access. See bug 1440231 comment 2.